### PR TITLE
Fixing Markdown headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
-#Notice
+# Notice
 
 The word2vec algorithms has been ported to the TeensorFlow architecture. See:
 https://www.tensorflow.org/versions/master/tutorials/word2vec/index.html
 
 Below is the deprecated word2vec implementation.
 
-##Introduction
+## Introduction
 
 This tool provides an efficient implementation of the continuous bag-of-words and skip-gram architectures for computing vector representations of words. These representations can be subsequently used in many natural language processing applications and for further research.
 
-##Quick start
+## Quick start
 * Run 'make' to compile word2vec tool
 * Run the demo scripts: ./demo-word.sh and ./demo-phrases.sh
 * For questions about the toolkit, see http://groups.google.com/group/word2vec-toolkit
 
-##How does it work
+## How does it work
 The word2vec tool takes a text corpus as input and produces the word vectors as output. It first constructs a vocabulary from the training text data and then learns vector representation of words. The resulting word vector file can be used as features in many natural language processing and machine learning applications.
 
 A simple way to investigate the learned representations is to find the closest words for a user-specified word. The distance tool serves that purpose. For example, if you enter 'france', distance will display the most similar words and their distances to 'france', which should look like:
@@ -36,10 +36,10 @@ A simple way to investigate the learned representations is to find the closest w
 
 There are two main learning algorithms in word2vec : continuous bag-of-words and continuous skip-gram. The switch -cbow allows the user to pick one of these learning algorithms. Both algorithms learn the representation of a word that is useful for prediction of other words in the sentence. These algorithms are described in detail in [1,2].
 
-##Interesting properties of the word vectors
+## Interesting properties of the word vectors
 It was recently shown that the word vectors capture many linguistic regularities, for example vector operations vector('Paris') - vector('France') + vector('Italy') results in a vector that is very close to vector('Rome'), and vector('king') - vector('man') + vector('woman') is close to vector('queen') [3, 1]. You can try out a simple demo by running demo-analogy.sh.
 
-##How to measure quality of the word vectors
+## How to measure quality of the word vectors
 Several factors influence the quality of the word vectors:
 * amount and quality of the training data
 * size of the vectors
@@ -49,7 +49,7 @@ The quality of the vectors is crucial for any application. However, exploration 
 
 For the word relation test set described in [1], see ./demo-word-accuracy.sh, for the phrase relation test set described in [2], see ./demo-phrase-accuracy.sh. Note that the accuracy depends heavily on the amount of the training data; our best results for both test sets are above 70% accuracy with coverage close to 100%.
 
-##Word clustering
+## Word clustering
 The word vectors can be also used for deriving word classes from huge data sets. This is achieved by performing K-means clustering on top of the word vectors. The script that demonstrates this is ./demo-classes.sh. The output is a vocabulary file with words and their corresponding class IDs, such as:
 
 ```shell
@@ -78,7 +78,7 @@ challenge 412
 claim 412
 ```
 
-##Performance
+## Performance
 The training speed can be significantly improved by using parallel training on multiple-CPU machine (use the switch '-threads N'). The hyper-parameter choice is crucial for performance (both speed and accuracy), however varies for different applications. The main choices to make are:
 * architecture: skip-gram (slower, better for infrequent words) vs CBOW (fast)
 * the training algorithm: hierarchical softmax (better for infrequent words) vs negative sampling (better for frequent words, better with low dimensional vectors)
@@ -86,7 +86,7 @@ The training speed can be significantly improved by using parallel training on m
 * dimensionality of the word vectors: usually more is better, but not always
 * context (window) size: for skip-gram usually around 10, for CBOW around 5
 
-##Where to obtain the training data
+## Where to obtain the training data
 The quality of the word vectors increases significantly with amount of the training data. For research purposes, you can consider using data sets that are available on-line:
 * [First billion characters from wikipedia](http://mattmahoney.net/dc/enwik9.zip) (use the pre-processing perl script from the bottom of [Matt Mahoney's page](http://mattmahoney.net/dc/textdata.html))
 * [Latest Wikipedia dump](http://dumps.wikimedia.org/enwiki/latest/enwiki-latest-pages-articles.xml.bz2) Use the same script as above to obtain clean text. Should be more than 3 billion words.
@@ -95,7 +95,7 @@ The quality of the word vectors increases significantly with amount of the train
 * [UMBC webbase corpus](http://ebiquity.umbc.edu/redirect/to/resource/id/351/UMBC-webbase-corpus) Around 3 billion words, more info [here](http://ebiquity.umbc.edu/blogger/2013/05/01/umbc-webbase-corpus-of-3b-english-words/). Needs further processing (mainly tokenization).
 * Text data from more languages can be obtained at [statmt.org](http://statmt.org/) and in the [Polyglot project](https://sites.google.com/site/rmyeid/projects/polyglot#TOC-Download-Wikipedia-Text-Dumps).
 
-##Pre-trained word and phrase vectors
+## Pre-trained word and phrase vectors
 We are publishing pre-trained vectors trained on part of Google News dataset (about 100 billion words). The model contains 300-dimensional vectors for 3 million words and phrases. The phrases were obtained using a simple data-driven approach described in [2]. The archive is available here: [GoogleNews-vectors-negative300.bin.gz](https://drive.google.com/file/d/0B7XkCwpI5KDYNlNUTTlSS21pQmM/edit?usp=sharing).
 
 An example output of ./distance GoogleNews-vectors-negative300.bin:
@@ -119,7 +119,7 @@ Enter word or sentence (EXIT to break): Chinese river
 
 The above example will average vectors for words 'Chinese' and 'river' and will return the closest neighbors to the resulting vector. More examples that demonstrate results of vector addition are presented in [2]. Note that more precise and disambiguated entity vectors can be found in the following dataset that uses Freebase naming.
 
-##Pre-trained entity vectors with Freebase naming
+## Pre-trained entity vectors with Freebase naming
 We are also offering more than 1.4M pre-trained entity vectors with naming from [Freebase](http://www.freebase.com/). This is especially helpful for projects related to knowledge mining.
 
 * Entity vectors trained on 100B words from various news articles: [freebase-vectors-skipgram1000.bin.gz](https://docs.google.com/file/d/0B7XkCwpI5KDYaDBDQm1tZGNDRHc/edit?usp=sharing)
@@ -144,10 +144,10 @@ Enter word or sentence (EXIT to break): /en/geoffrey_hinton
              /en/godel_prize              0.405176
 ```
 
-##Final words
+## Final words
 Thank you for trying out this toolkit, and do not forget to let us know when you obtain some amazing results! We hope that the distributed representations will significantly improve the state of the art in NLP.
 
-##References
+## References
 
 [1] Tomas Mikolov, Kai Chen, Greg Corrado, and Jeffrey Dean. [Efficient Estimation of Word Representations in Vector Space](http://arxiv.org/pdf/1301.3781.pdf). In Proceedings of Workshop at ICLR, 2013.
 
@@ -171,6 +171,6 @@ Comparison with traditional count-based vectors and cbow model trained on a diff
 
 Link to slides about word vectors from NIPS 2013 Deep Learning Workshop: [NNforText.pdf](https://drive.google.com/file/d/0B7XkCwpI5KDYRWRnd1RzWXQ2TWc/edit?usp=sharing)
 
-##Disclaimer
+## Disclaimer
 
 This open source project is NOT a Google product, and is released for research purposes only.


### PR DESCRIPTION
Adding spaces after the octothorpes so that the headers are rendered correctly.